### PR TITLE
Improve output logging

### DIFF
--- a/tasks/template.js
+++ b/tasks/template.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
 			}
 
 			// Print a success message
-			grunt.log.write('Processing file `' + file.dest + '`...');
+			grunt.log.write('Processing file `' + file.dest + '`…');
 
 			var result = grunt.template.process(template, templateOptions);
 
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
 			grunt.file.write(file.dest, result);
 
 			// Print a success message
-			grunt.log.writeln('done !');
+			grunt.log.writeln('done!');
 		});
 	});
 

--- a/tasks/template.js
+++ b/tasks/template.js
@@ -46,13 +46,16 @@ module.exports = function(grunt) {
 					options.delimiters;
 			}
 
+			// Print a success message
+			grunt.log.write('Processing file `' + file.dest + '`...');
+
 			var result = grunt.template.process(template, templateOptions);
 
 			// Write the destination file
 			grunt.file.write(file.dest, result);
 
 			// Print a success message
-			grunt.log.writeln('File `' + file.dest + '` created.');
+			grunt.log.writeln('done !');
 		});
 	});
 


### PR DESCRIPTION
When a template contains invalid JS the error generated is not much helpful as the user does not know which files is concerned.

To improve this behavior this change introduce a pre processing message, followed by a confirmation message for each file processed.